### PR TITLE
[DEN-373] Update Rules Engine Service URL to BaseAPIURL (IDS) vs legacy API URL

### DIFF
--- a/edgecast/rulesengine/service.go
+++ b/edgecast/rulesengine/service.go
@@ -36,7 +36,7 @@ func New(config edgecast.SDKConfig) (*RulesEngineService, error) {
 
 	c := ecclient.New(ecclient.ClientConfig{
 		AuthProvider: authProvider,
-		BaseAPIURL:   config.BaseAPIURLLegacy,
+		BaseAPIURL:   config.BaseAPIURL,
 		UserAgent:    config.UserAgent,
 		Logger:       config.Logger,
 	})


### PR DESCRIPTION
This is a bug fix to point to the proper URL going forward. The client currently works with the legacy API URL, so this is essentially a no-op for customers using this feature now.