### PR TITLE
DEN-397 Improved Error Handling in IDS Client

### DIFF
--- a/edgecast/internal/ecauth/ids_client.go
+++ b/edgecast/internal/ecauth/ids_client.go
@@ -65,7 +65,7 @@ func (c IDSClient) GetToken(
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf(
-			"expected 200 OK, Received Status code %v", resp.StatusCode,
+			"expected 200 OK, received status code %v", resp.StatusCode,
 		)
 	}
 

--- a/edgecast/internal/ecauth/ids_client.go
+++ b/edgecast/internal/ecauth/ids_client.go
@@ -54,6 +54,21 @@ func (c IDSClient) GetToken(
 		return nil, err
 	}
 
+	if resp.StatusCode == http.StatusBadRequest {
+		errorResponse := &OAuth2ErrorResponse{}
+		err = json.NewDecoder(resp.Body).Decode(&errorResponse)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("bad request: %s", errorResponse.Error)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"expected 200 OK, Received Status code %v", resp.StatusCode,
+		)
+	}
+
 	tokenResponse := &OAuth2TokenResponse{}
 	err = json.NewDecoder(resp.Body).Decode(&tokenResponse)
 

--- a/edgecast/internal/ecauth/ids_client.go
+++ b/edgecast/internal/ecauth/ids_client.go
@@ -7,10 +7,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
 )
+
+const errorPrefix string = "authentication error:"
 
 // Calls the IDS token endpoint
 type IDSClient struct {
@@ -39,7 +42,8 @@ func (c IDSClient) GetToken(
 		bytes.NewBufferString(dataString))
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s failed creating HTTP request: %w",
+			errorPrefix, err)
 	}
 
 	newTokenRequest.Header.Add(
@@ -51,29 +55,41 @@ func (c IDSClient) GetToken(
 	resp, err := httpClient.Do(newTokenRequest)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s HTTP request failed: %w", errorPrefix, err)
 	}
 
 	if resp.StatusCode == http.StatusBadRequest {
-		errorResponse := &OAuth2ErrorResponse{}
-		err = json.NewDecoder(resp.Body).Decode(&errorResponse)
+		oAuth2Error := &OAuth2ErrorResponse{}
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%s error reading HTTP response: %w",
+				errorPrefix, err)
 		}
-		return nil, fmt.Errorf("bad request: %s", errorResponse.Error)
+
+		err = json.Unmarshal(bodyBytes, oAuth2Error)
+		if err != nil {
+			// Cannot decode to oAuth2Error so return complete response body
+			return nil, fmt.Errorf("%s error parsing oAuth2Error response: %s",
+				errorPrefix, bodyBytes)
+		}
+
+		return nil, fmt.Errorf("%s bad request: %s",
+			errorPrefix, oAuth2Error.Error)
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf(
-			"expected 200 OK, received status code %v", resp.StatusCode,
-		)
+			"%s expected 200 OK, received status code %d", errorPrefix,
+			resp.StatusCode)
 	}
 
 	tokenResponse := &OAuth2TokenResponse{}
 	err = json.NewDecoder(resp.Body).Decode(&tokenResponse)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s error decoding token response: %w",
+			errorPrefix, err)
 	}
 
 	return tokenResponse, nil

--- a/edgecast/internal/ecauth/oauth2.go
+++ b/edgecast/internal/ecauth/oauth2.go
@@ -19,6 +19,11 @@ type OAuth2TokenResponse struct {
 	Scope       string  `json:"scope"`
 }
 
+// OAuth2ErrorResponse represents an error response from an identity server
+type OAuth2ErrorResponse struct {
+	Error string `json:"error"`
+}
+
 // Defines structs that can retrieve OAuth 2.0 Tokens
 type OAuth2Client interface {
 	GetToken(credentials OAuth2Credentials) (*OAuth2TokenResponse, error)


### PR DESCRIPTION
1) Handle 400 error response when requesting AccessToken from IDS
2) Handle non-200 error response from AccessToken request from IDS
3) Add Error struct for single error Hyperion response