### PR TITLE
DEN-398 Allow removal of a directory path from an Edge CNAME

### DIFF
--- a/edgecast/edgecname/edgecname_models.go
+++ b/edgecast/edgecname/edgecname_models.go
@@ -29,7 +29,7 @@ type EdgeCname struct {
 	// the relative path from the root folder of the origin server to the
 	// desired location. Set this parameter to blank to point the edge CNAME to
 	// the root folder of the origin server.
-	DirPath string `json:"DirPath,omitempty"`
+	DirPath string `json:"DirPath"`
 
 	// Determines whether hits and data transferred statistics will be tracked
 	// for this edge CNAME. Logged data can be viewed through the Custom Reports


### PR DESCRIPTION
Remove omitempty tag from DirPath property in the model since passing an empty value is a valid use case to change behavior