### PR TITLE
[DEN-315] OriginV3 Group Management Examples

### DIFF
--- a/edgecast/ecutils/convert.go
+++ b/edgecast/ecutils/convert.go
@@ -1,0 +1,36 @@
+package ecutils
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// This function is used to convert a struct to the provided type.
+// If dest must be a pointer otherwise an error is returned.
+// Please refer to the json unmashall documentation for additional information
+// on expected behavior.
+//
+// Field names need to match between the source and destination structs. This
+// function should be used wisely when the source and destination are well known.
+func Convert(src, dest any) error {
+	rv := reflect.ValueOf(dest)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return errors.New("dest must be a pointer")
+	}
+
+	// Marshal src to json bytes
+	srcBytes, err := json.Marshal(src)
+	if err != nil {
+		return fmt.Errorf(
+			"unable to marshal get origin group response: %w", err)
+	}
+
+	// Unmarshal into dest
+	err = json.Unmarshal(srcBytes, dest)
+	if err != nil {
+		return fmt.Errorf("failed to convert %T to %T: %w", src, dest, err)
+	}
+	return nil
+}

--- a/edgecast/ecutils/convert.go
+++ b/edgecast/ecutils/convert.go
@@ -7,9 +7,14 @@ import (
 	"reflect"
 )
 
+var (
+	jsonMarshal   = json.Marshal
+	jsonUnmarshal = json.Unmarshal
+)
+
 // This function is used to convert a struct to the provided type.
-// If dest must be a pointer otherwise an error is returned.
-// Please refer to the json unmashall documentation for additional information
+// Dest must be a pointer otherwise an error is returned.
+// Please refer to the json unmarshall documentation for additional information
 // on expected behavior.
 //
 // Field names need to match between the source and destination structs. This
@@ -17,18 +22,18 @@ import (
 func Convert(src, dest any) error {
 	rv := reflect.ValueOf(dest)
 	if rv.Kind() != reflect.Pointer || rv.IsNil() {
-		return errors.New("dest must be a pointer")
+		return errors.New("dest must be a pointer and not nil")
 	}
 
 	// Marshal src to json bytes
-	srcBytes, err := json.Marshal(src)
+	srcBytes, err := jsonMarshal(src)
 	if err != nil {
 		return fmt.Errorf(
-			"unable to marshal get origin group response: %w", err)
+			"unable to marshal src: %s err: %w", src, err)
 	}
 
 	// Unmarshal into dest
-	err = json.Unmarshal(srcBytes, dest)
+	err = jsonUnmarshal(srcBytes, dest)
 	if err != nil {
 		return fmt.Errorf("failed to convert %T to %T: %w", src, dest, err)
 	}

--- a/edgecast/ecutils/convert_test.go
+++ b/edgecast/ecutils/convert_test.go
@@ -1,0 +1,104 @@
+package ecutils
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+type marshal func(v any) ([]byte, error)
+type unmarshal func(data []byte, v any) error
+
+type srcStruct struct {
+	ID   int
+	Name string
+}
+
+type destStruct struct {
+	ID   int
+	Name string
+}
+
+func TestConvert(t *testing.T) {
+	cases := []struct {
+		Name          string
+		SrcStruct     *srcStruct
+		DestStruct    *destStruct
+		ExpectedError bool
+		Marshal       marshal
+		Unmarshal     unmarshal
+	}{
+		{
+			Name:          "Happy path",
+			SrcStruct:     &srcStruct{ID: 1, Name: "First"},
+			DestStruct:    &destStruct{},
+			ExpectedError: false,
+			Marshal:       json.Marshal,
+			Unmarshal:     json.Unmarshal,
+		},
+		{
+			Name:          "Nil src returns error",
+			SrcStruct:     nil,
+			DestStruct:    nil,
+			ExpectedError: true,
+			Marshal:       json.Marshal,
+			Unmarshal:     json.Unmarshal,
+		},
+		{
+			Name:          "Marshal failure returns error",
+			SrcStruct:     &srcStruct{ID: 1, Name: "First"},
+			DestStruct:    &destStruct{},
+			ExpectedError: true,
+			Marshal:       failJsonMarshal,
+			Unmarshal:     json.Unmarshal,
+		},
+		{
+			Name:          "Unmarshal failure returns error",
+			SrcStruct:     &srcStruct{ID: 1, Name: "First"},
+			DestStruct:    &destStruct{},
+			ExpectedError: true,
+			Marshal:       jsonMarshal,
+			Unmarshal:     failJsonUnmarshal,
+		},
+	}
+
+	for _, v := range cases {
+		jsonMarshal = v.Marshal
+		jsonUnmarshal = v.Unmarshal
+
+		err := Convert(v.SrcStruct, v.DestStruct)
+
+		if !v.ExpectedError && err != nil {
+			t.Fatalf("Failed for case: '%+v'. Error not expected, but got `%s`", v.Name, err)
+		}
+
+		if v.ExpectedError && err == nil {
+			t.Fatalf("Failed for case: '%+v'. Expected an error, but did not get one", v.Name)
+		}
+
+		if v.ExpectedError && err != nil {
+			t.Logf("Received expected error: %v", err)
+			continue
+		}
+
+		if !SrcEqualsDest(*v.SrcStruct, *v.DestStruct) {
+			t.Fatalf("Failed for case: '%+v'. Expected '%+v', but got '%+v'", v.Name, *v.SrcStruct, *v.DestStruct)
+		}
+	}
+
+}
+
+func SrcEqualsDest(source srcStruct, dest destStruct) bool {
+	if (source.ID != dest.ID) || (source.Name != dest.Name) {
+		return false
+	}
+	return true
+}
+
+func failJsonMarshal(v any) ([]byte, error) {
+	return []byte{}, errors.New("marshal failure")
+}
+
+func failJsonUnmarshal(data []byte, v any) error {
+	return errors.New("unmarshal failure")
+}

--- a/edgecast/edgecname/edgecname.go
+++ b/edgecast/edgecname/edgecname.go
@@ -21,7 +21,7 @@ func (svc *EdgeCnameService) GetAllEdgeCnames(
 		Path:   "v2/mcc/customers/{account_number}/cnames/{platform_id}",
 		PathParams: map[string]string{
 			"account_number": params.AccountNumber,
-			"platform_id":    params.Platform.String(),
+			"platform_id":    params.Platform.StringWithoutHyphen(),
 		},
 		ParsedResponse: parsedResponse,
 	})

--- a/edgecast/origin/origin.go
+++ b/edgecast/origin/origin.go
@@ -21,7 +21,7 @@ func (svc *OriginService) GetAllOrigins(
 		Path:   "v2/mcc/customers/{account_number}/origins/{platform_id}",
 		PathParams: map[string]string{
 			"account_number": params.AccountNumber,
-			"platform_id":    params.MediaTypeID.String(),
+			"platform_id":    params.MediaTypeID.StringWithoutHyphen(),
 		},
 		ParsedResponse: parsedResponse,
 	})
@@ -39,7 +39,7 @@ func (svc *OriginService) AddOrigin(params AddOriginParams) (*int, error) {
 		Path:   "v2/mcc/customers/{account_number}/origins/{platform_id}",
 		PathParams: map[string]string{
 			"account_number": params.AccountNumber,
-			"platform_id":    params.MediaTypeID.String(),
+			"platform_id":    params.MediaTypeID.StringWithoutHyphen(),
 		},
 		RawBody:        params.Origin,
 		ParsedResponse: parsedResponse,
@@ -60,7 +60,7 @@ func (svc *OriginService) GetOrigin(
 		Path:   "v2/mcc/customers/{account_number}/origins/{platform_id}/{origin_id}",
 		PathParams: map[string]string{
 			"account_number": params.AccountNumber,
-			"platform_id":    params.MediaTypeID.String(),
+			"platform_id":    params.MediaTypeID.StringWithoutHyphen(),
 			"origin_id":      strconv.Itoa(params.CustomerOriginID),
 		},
 		ParsedResponse: parsedResponse,
@@ -81,7 +81,7 @@ func (svc *OriginService) UpdateOrigin(
 		Path:   "v2/mcc/customers/{account_number}/origins/{platform_id}/{origin_id}",
 		PathParams: map[string]string{
 			"account_number": params.AccountNumber,
-			"platform_id":    params.Origin.MediaTypeID.String(),
+			"platform_id":    params.Origin.MediaTypeID.StringWithoutHyphen(),
 			"origin_id":      strconv.Itoa(params.Origin.ID),
 		},
 		RawBody:        params.Origin,
@@ -162,7 +162,7 @@ func (svc *OriginService) GetOriginShieldPOPs(
 		Path:   "v2/mcc/customers/{account_number}/origins/{platform_id}/shieldpops",
 		PathParams: map[string]string{
 			"account_number": params.AccountNumber,
-			"platform_id":    params.MediaTypeID.String(),
+			"platform_id":    params.MediaTypeID.StringWithoutHyphen(),
 		},
 		ParsedResponse: parsedResponse,
 	})
@@ -183,7 +183,7 @@ func (svc *OriginService) ReselectADNGateways(
 		Path:   "v2/mcc/customers/{account_number}/origins/{platform_id}/{origin_id}/reselect",
 		PathParams: map[string]string{
 			"account_number": params.AccountNumber,
-			"platform_id":    params.MediaTypeID.String(),
+			"platform_id":    params.MediaTypeID.StringWithoutHyphen(),
 			"origin_id":      strconv.Itoa(params.CustomerOriginID),
 		},
 	})

--- a/edgecast/shared/enums/global.go
+++ b/edgecast/shared/enums/global.go
@@ -3,6 +3,8 @@
 
 package enums
 
+import "strings"
+
 type Platform int
 
 const (
@@ -14,11 +16,15 @@ const (
 func (p Platform) String() string {
 	switch p {
 	case HttpLarge:
-		return "httplarge"
+		return "http-large"
 	case HttpSmall:
-		return "httpsmall"
+		return "http-small"
 	case ADN:
 		return "adn"
 	}
 	return "unknown"
+}
+
+func (p Platform) StringWithoutHyphen() string {
+	return strings.Replace(p.String(), "-", "", 1)
 }

--- a/edgecast/shared/enums/global_test.go
+++ b/edgecast/shared/enums/global_test.go
@@ -1,0 +1,51 @@
+package enums_test
+
+import (
+	"testing"
+
+	"github.com/EdgeCast/ec-sdk-go/edgecast/shared/enums"
+)
+
+func TestEnums(t *testing.T) {
+	cases := []struct {
+		Name                  string
+		Enum                  enums.Platform
+		ExpectedHyphen        string
+		ExpectedWithoutHyphen string
+	}{
+		{
+			Name:                  "Happy path HTTP Large",
+			Enum:                  enums.HttpLarge,
+			ExpectedHyphen:        "http-large",
+			ExpectedWithoutHyphen: "httplarge",
+		},
+		{
+			Name:                  "Happy path HTTP Small",
+			Enum:                  enums.HttpSmall,
+			ExpectedHyphen:        "http-small",
+			ExpectedWithoutHyphen: "httpsmall",
+		},
+		{
+			Name:                  "Happy path ADN",
+			Enum:                  enums.ADN,
+			ExpectedHyphen:        "adn",
+			ExpectedWithoutHyphen: "adn",
+		},
+	}
+
+	for _, v := range cases {
+		withHyphen := v.Enum.String()
+		withoutHyphen := v.Enum.StringWithoutHyphen()
+
+		if v.ExpectedHyphen != withHyphen {
+			t.Fatalf("Failed for case: '%+v'. Expected: %s, Got: %s",
+				v.Name, v.ExpectedHyphen, withHyphen)
+		}
+
+		if v.ExpectedWithoutHyphen != withoutHyphen {
+			t.Fatalf("Failed for case: '%+v'. Expected: %s, Got: %s",
+				v.Name, v.ExpectedWithoutHyphen, withoutHyphen)
+		}
+
+	}
+}

--- a/example/originv3/groups/httplarge.go
+++ b/example/originv3/groups/httplarge.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/EdgeCast/ec-sdk-go/edgecast"
+	"github.com/EdgeCast/ec-sdk-go/edgecast/originv3"
+	"github.com/EdgeCast/ec-sdk-go/edgecast/shared/enums"
+	"github.com/kr/pretty"
+)
+
+func main() {
+
+	// Setup
+	//apiToken := "MY_API_TOKEN"
+
+	idsCredentials := edgecast.IDSCredentials{
+		ClientID:     "",
+		ClientSecret: "",
+		Scope:        "cdn.origins",
+	}
+
+	sdkConfig := edgecast.NewSDKConfig()
+	sdkConfig.IDSCredentials = idsCredentials
+
+	originV3Service, err := originv3.New(sdkConfig)
+
+	if err != nil {
+		fmt.Printf("error creating service: %v\n", err)
+		return
+	}
+
+	// Create Group
+	originGroupRequest := createOriginGroupRequest()
+	createGroupParams := originv3.NewPostHttpLargeGroupsParams()
+	createGroupParams.CustomerOriginGroupHTTPRequest = originGroupRequest
+	originGroup, err := originV3Service.HttpLargeOnly.PostHttpLargeGroups(
+		createGroupParams,
+	)
+
+	if err != nil {
+		fmt.Printf("error creating origin group: %v\n", err)
+		return
+	}
+
+	fmt.Println("successfully created origin group")
+	fmt.Printf("%# v", pretty.Formatter(originGroup))
+
+	// Get Group by ID
+	getGroupParams := originv3.NewGetHttpLargeGroupsGroupIdParams()
+	getGroupParams.GroupId = strconv.Itoa(int(*originGroup.Id))
+	originGroup, err = originV3Service.HttpLargeOnly.GetHttpLargeGroupsGroupId(
+		getGroupParams,
+	)
+
+	if err != nil {
+		fmt.Printf("error retrieving origin group by ID: %v\n", err)
+		return
+	}
+
+	fmt.Println("successfully retrieved origin group by ID")
+	fmt.Printf("%# v", pretty.Formatter(originGroup))
+
+	// Get Shield POPs
+	getShieldPOPsParams := originv3.NewGetHttpLargeShieldPopsParams()
+	edgeNodes, err := originV3Service.HttpLargeOnly.GetHttpLargeShieldPops(
+		getShieldPOPsParams,
+	)
+
+	if err != nil {
+		fmt.Printf("error retrieving shield POPs: %v\n", err)
+		return
+	}
+
+	fmt.Println("successfully retrieved origin shield POPs")
+	fmt.Printf("%# v", pretty.Formatter(edgeNodes))
+
+	// Convert group retreived from API to proper update model
+	updateGroup, err := convertGetToUpdate(*originGroup)
+	if err != nil {
+		fmt.Printf("error preparing group update respose: %v\n", err)
+		return
+	}
+
+	// Update Group with shield POP
+	shieldPOPs := []*string{}
+	shieldPOPs = append(shieldPOPs,
+		edgeNodes[0].Pops[0].Code,
+		edgeNodes[1].Pops[1].Code,
+	)
+
+	updateGroup.ShieldPops = shieldPOPs
+
+	updateGroupParams := originv3.NewPutHttplargeGroupsGroupIdParams()
+	updateGroupParams.GroupId = strconv.Itoa(int(*originGroup.Id))
+	updateGroupParams.CustomerOriginGroupHTTPRequest = *updateGroup
+
+	originGroup, err = originV3Service.HttpLargeOnly.PutHttplargeGroupsGroupId(
+		updateGroupParams,
+	)
+
+	if err != nil {
+		fmt.Printf("error updating origin group: %v\n", err)
+		return
+	}
+
+	fmt.Println("successfully updated origin group")
+	fmt.Printf("%# v", pretty.Formatter(originGroup))
+
+	// Get all Groups
+	originGroups, err := originV3Service.HttpLargeOnly.GetHttpLargeGroups()
+
+	if err != nil {
+		fmt.Printf("error retrieving all origin groups: %v\n", err)
+		return
+	}
+
+	fmt.Println("successfully retrieved all origin groups")
+	fmt.Printf("%# v", pretty.Formatter(originGroups))
+
+	// Delete Group
+	deleteOriginGroupParams := originv3.NewDeleteMediaTypeGroupsGroupIdParams()
+	deleteOriginGroupParams.GroupId = strconv.Itoa(int(*originGroup.Id))
+	deleteOriginGroupParams.MediaType = enums.HttpLarge.String()
+
+	err = originV3Service.Common.DeleteMediaTypeGroupsGroupId(
+		deleteOriginGroupParams,
+	)
+
+	if err != nil {
+		fmt.Printf("error deleting origin group: %v\n", err)
+		return
+	}
+}
+
+func createOriginGroupRequest() originv3.CustomerOriginGroupHTTPRequest {
+	tlsSettings := originv3.TlsSettings{
+		PublicKeysToVerify: []string{
+			"ff8b4a82b08ea5f7be124e6b4363c00d7462655f",
+			"c571398b01fce46a8a177abdd6174dfee6137358",
+		},
+	}
+	tlsSettings.SetAllowSelfSigned(false)
+	tlsSettings.SetSniHostname("origin.example.com")
+
+	origin := originv3.CustomerOriginGroupHTTPRequest{
+		Name:        "TestSDKOriginGroup1",
+		TlsSettings: &tlsSettings,
+	}
+	origin.SetHostHeader("override-hostheader.example.com")
+	origin.SetNetworkTypeId(2)          // Prefer IPv6 over IPv4
+	origin.SetStrictPciCertified(false) // Allow non-PCI regions
+
+	return origin
+}
+
+func convertGetToUpdate(
+	groupGet originv3.CustomerOriginGroupHTTP) (
+	*originv3.CustomerOriginGroupHTTPRequest, error) {
+	groupGetBytes, err := json.Marshal(groupGet)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"unable to marshal get origin group response: %w", err)
+	}
+
+	groupUpdate := &originv3.CustomerOriginGroupHTTPRequest{}
+	err = json.Unmarshal(groupGetBytes, groupUpdate)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"unable to unmarshal group get into group update: %w", err)
+	}
+
+	return groupUpdate, nil
+}


### PR DESCRIPTION
1) Added OriginV3 group management examples
2) Refactored Platform enum default String() case to return platform with hyphen
3) Added StringWithoutHyphen method for convenience
4) Refactored previous usages of Platform.String() to PlatformWithoutString() to match previous default behavior
5) Added ecutils and Convert() to convert one struct to another
6) Added unit tests for Convert() and Platform enum